### PR TITLE
fix: enable web security, alert from CodeQL

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -51,7 +51,7 @@ function createWindow() {
     icon: path.join(process.env.VITE_PUBLIC || '', 'app-icon.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.mjs'),
-      webSecurity: false, // Permettre le chargement des ressources locales
+      webSecurity: true,
     },
   })
 


### PR DESCRIPTION
This pull request includes a security improvement to the `electron/main.ts` file. The change enables web security in the `createWindow` function to prevent loading local resources.

Security improvement:

* [`electron/main.ts`](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL54-R54): Changed the `webSecurity` option in the `webPreferences` object from `false` to `true` in the `createWindow` function to enhance security by disallowing the loading of local resources.